### PR TITLE
fixed "#page-top" scrolling problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 <div class="container-flud">
 	
 	
-  <div class="bg-black section text-white d-flex align-items-end py-5">
+  <div id="page-top" class="bg-black section text-white d-flex align-items-end py-5">
     <div class="text-left p-5">
 		<h1 class="title">+Jakarta Sans</h1>
 		          <p class="subtitle">Open-source Fonts for Jakarta City of Collaboration</p>


### PR DESCRIPTION
When we click on the logo in current website on [https://tokotype.github.io/plusjakarta-sans/](https://tokotype.github.io/plusjakarta-sans/) the page **doesn't scroll** to the top section.

I did just a small tweak to fix that issue in this PR.